### PR TITLE
프로그래머스 LV1 약수의 합 문제

### DIFF
--- a/고석환/프로그래머스/LV1_약수의_합/solution.cpp
+++ b/고석환/프로그래머스/LV1_약수의_합/solution.cpp
@@ -1,0 +1,16 @@
+#include <string>
+#include <vector>
+
+using namespace std;
+
+int solution(int n) {
+  int answer = 0;
+
+  for (int i = 1; i <= n; i++) {
+    if (!(n % i)) answer += i;
+  }
+
+  return answer;
+} 
+
+// n이 최대 3000이므로 1~n 까지 반복문 돌려서 단순 비교

--- a/고석환/프로그래머스/LV1_약수의_합/solution.js
+++ b/고석환/프로그래머스/LV1_약수의_합/solution.js
@@ -1,0 +1,9 @@
+function solution(n) {
+    let answer = 0;
+    
+    for (let i=1; i<=n; i++){
+        if(!(n % i)) answer += i;
+    }
+    
+    return answer;
+}


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름: 약수의 합**
- **출처: 프로그래머스** 

## 🚀 해결 방법
- 실제 약수를 구하는 방식을 사용하여 반복문을 통해 구현

## 📌 핵심 아이디어
- n은 3000 이하의 정수이므로 단순 반복문을 통해 구해도 시간초과 x

## ⏳ 시간 복잡도
- O(n)

## ✅ 실행 결과
- [ ] 테스트 케이스 통과 여부
![스크린샷 2025-03-25 오전 11 16 45](https://github.com/user-attachments/assets/9f17db67-6018-4483-8863-6a866bab28f0)

- [ ] 코드 실행 결과 (예제 입력/출력 포함)
![스크린샷 2025-03-25 오전 11 16 13](https://github.com/user-attachments/assets/328ddde8-4a59-4b5f-b61e-2a9b8e487721)

## 💡 기타 참고 사항
- 추가로 반복문을 `sqrt(n)` 까지만 돌려서 코드 실행 횟수를 줄일 수 있음
- 12의 약수를 구할 때 3, 4 짝을 한번에 구한다는 아이디어

