### PR TITLE
프로그래머스_LV.1_문자열내p와y의개수

### DIFF
--- a/이재인/프로그래머스/LV_1/LV.1_나머지가1이되는수찾기.py
+++ b/이재인/프로그래머스/LV_1/LV.1_나머지가1이되는수찾기.py
@@ -1,0 +1,10 @@
+Python 3.11.4 (v3.11.4:d2340ef257, Jun  6 2023, 19:15:51) [Clang 13.0.0 (clang-1300.0.29.30)] on darwin
+Type "help", "copyright", "credits" or "license()" for more information.
+>>> def solution(n):
+...     answer=1
+...     while 1:
+...         if n % answer ==1:
+...             break
+...         answer+=1
+...     return answer
+... 

--- a/이재인/프로그래머스/LV_1/LV.1_두정수사이의합.py
+++ b/이재인/프로그래머스/LV_1/LV.1_두정수사이의합.py
@@ -1,0 +1,9 @@
+def solution(a, b):
+    answer = 0
+    if a<b:
+        for i in range(a, b+1, 1):
+            answer += i
+    else:
+        for i in range(b, a+1, 1):
+            answer += i
+    return answer

--- a/이재인/프로그래머스/LV_1/LV.1_문자열내p와y의개수.py
+++ b/이재인/프로그래머스/LV_1/LV.1_문자열내p와y의개수.py
@@ -1,0 +1,5 @@
+Python 3.11.4 (v3.11.4:d2340ef257, Jun  6 2023, 19:15:51) [Clang 13.0.0 (clang-1300.0.29.30)] on darwin
+Type "help", "copyright", "credits" or "license()" for more information.
+>>> def solution(s):
+...     if s.count('p') + s.count('P') == s.count('y') + s.count('Y'):
+...         return True


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름:** LV.1_문자열내p와y의개수
- **출처:** 프로그래머스

## 🚀 해결 방법
- count()함수를 이용해 값 비교하여 boolean 값 리턴

## 📌 핵심 아이디어
- count()함수로 대소문자를 모두 카운트하고 p와 y의 갯수 비교

## ⏳ 시간 복잡도
- O(N )

## ✅ 실행 결과
- [ ] 테스트 케이스 통과 여부
![스크린샷 2025-03-26 시간: 16 25 23](https://github.com/user-attachments/assets/721d9102-ecef-4d56-aa0c-057a28c5061d)

- [ ] 코드 실행 결과 (예제 입력/출력 포함)
![스크린샷 2025-03-26 시간: 16 25 12](https://github.com/user-attachments/assets/3f13023d-05f2-4283-80cb-02bfeecc2561)

## 💡 기타 참고 사항
- (추가적으로 공유할 내용이 있다면 적어주세요)

