### PR TITLE
ksh / 백준 S 1629 곱셈 풀이

### DIFF
--- a/고석환/백준/S1_1629_곱셈/solution.cpp
+++ b/고석환/백준/S1_1629_곱셈/solution.cpp
@@ -1,0 +1,37 @@
+#include <bits/stdc++.h>
+using namespace std;
+typedef long long ll;
+
+ll A, B, C;
+
+// ll go(ll a, ll b) {
+//   if (b <= 1) return a % C;
+
+//   ll ret = go(a, b / 2);
+
+//   ret = ret * ret % C;
+
+//   if (b % 2 == 1) {
+//     ret = ret * a % C;
+//   }
+
+//   return ret;
+// }
+
+ll go(ll a, ll b) {
+  if (b <= 1) return a % C;
+
+  if (b % 2 == 1) {
+    return go(a, b / 2) * go(a, b / 2) % C * a % C;
+  }
+
+  return go(a, b / 2) * go(a, b / 2) % C;
+}
+
+int main() {
+  cin >> A >> B >> C;
+
+  cout << go(A, B);
+
+  return 0;
+}

--- a/고석환/백준/S1_1629_곱셈/solution.js
+++ b/고석환/백준/S1_1629_곱셈/solution.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+// const input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+const input = fs.readFileSync('./input.txt').toString().split(' ');
+
+const [A, B, C] = input.map(Number);
+
+const go = (a, b) => {
+  if(b <= 1) return a % C;
+  let ret = go(a, Math.floor(b/2));
+  
+  ret = (ret * ret) % C;
+  if(b % 2) ret = (ret * a) % C;
+  return ret;
+}
+
+const answer = (A, B, C) => {
+  console.log(A, B, C);
+
+  return go(A, B);
+}
+
+// gpt 코드
+// function modularExponentiation(a, b, c) {
+//   if (b === 0) return 1;
+//   let half = modularExponentiation(a, Math.floor(b / 2), c);
+//   let result = (half * half) % c;
+//   if (b % 2 !== 0) result = (result * a) % c;
+//   return result;
+// }
+
+console.log(answer(A, B, C));


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름: 곱셈** 
- **출처: 백준** 
- https://www.acmicpc.net/problem/1629

## 🚀 해결 방법
- 입력의 범위가 21억이기 때문에 단순 반복문 로직으로는 시간초과가 발생하고, long long 타입의 범위를 벗어남.
- 재귀를 통한 분할 정복과 모듈러 연산의 특징을 활용

## 📌 핵심 아이디어
- 단순 반복문을 돌리면 B가 21억일 경우 시간 초과 발생 
- 분할 정복과 정수론
- `A^B = A^(B/2) * A^(B/2)`
- `(A * B) mod N == (A mod N) * (B mod N)`

## ⏳ 시간 복잡도
- O(log(B))

## ✅ 실행 결과
![스크린샷 2025-04-04 오후 3 52 24](https://github.com/user-attachments/assets/8b3d56bc-a145-4f4b-8a9c-27bd55c72775)

## 💡 기타 참고 사항
- js의 경우 재귀가 깊어져 `Stack size exceeded` 런타임 에러 발생
풀이가 생각나지 않아, 지피티를 통해 다른 풀이를 받았는데 해당 풀이도 틀림...
일단 js는 보류

![IMG_4738](https://github.com/user-attachments/assets/fc462e6f-aebd-49c3-adfd-decfa56882af)
재귀 동작 방식 시각화

