### PR TITLE
17608:막대기

### DIFF
--- a/이재인/백준/2주차문제/17608:막대기.py
+++ b/이재인/백준/2주차문제/17608:막대기.py
@@ -1,0 +1,31 @@
+# n = int(input())
+# li=[]
+# for i in range(n):
+#     a = int(input())
+#     li.append(a)
+# answer = 0
+# max_stick = 0
+# for i in range(n-1, -1, -1):
+#     if max_stick < li[i]:
+#         max_stick = li[i]
+#         answer+=1
+# print(answer)
+
+import sys
+input = sys.stdin.readline
+
+n = int(input().strip())
+li = []
+
+for _ in range(n):
+    li.append(int(input().strip()))
+
+answer = 0
+max_stick = 0
+
+for i in range(n-1, -1, -1):
+    if max_stick < li[i]: 
+        max_stick = li[i] 
+        answer += 1  
+
+print(answer)


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름:** 17608:막대기
- **출처:** 백준

## 🚀 해결 방법
- 런타임 에러로 인해 sys.stdin.readline() 함수 사용

## 📌 핵심 아이디어
- sys.stdin.readline()은 표준 입력에서 한 줄만 읽어오기 때문에 반복문에서 여러 줄을 읽을 때 유용
- 문제에서 막대기 개수/높이가 10만까지 허용하기 때문에 런타임에러 방지하기 위해 사용

## ⏳ 시간 복잡도
- O( n)

## ✅ 실행 결과
- [ ] 테스트 케이스 통과 여부
- [ ] 코드 실행 결과 (예제 입력/출력 포함)
<img width="962" alt="스크린샷 2025-04-04 오후 11 43 49" src="https://github.com/user-attachments/assets/8d9b45b4-0e20-4f92-bbe1-df5282bb75e3" />

## 💡 기타 참고 사항
- (추가적으로 공유할 내용이 있다면 적어주세요)

