### PR TITLE
ksh / 백준 S3 14501 퇴사 풀이

### DIFF
--- a/고석환/백준/S3_14501_퇴사/solution.cpp
+++ b/고석환/백준/S3_14501_퇴사/solution.cpp
@@ -1,0 +1,34 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int N, temp1, temp2, dp[20];
+vector<pair<int, int>> v;
+
+int go(int idx) {
+  if (idx >= N) return 0;
+
+  int &ret = dp[idx];
+  if (ret != -1) return ret;
+
+  if (idx + v[idx].first <= N) {
+    ret = max(ret, go(idx + v[idx].first) + v[idx].second);
+  }
+
+  ret = max(ret, go(idx + 1));
+
+  return ret;
+}
+
+int main() {
+  cin >> N;
+  for (int i = 0; i < N; i++) {
+    cin >> temp1 >> temp2;
+    v.push_back({temp1, temp2});
+  }
+
+  memset(dp, -1, sizeof(dp));
+
+  cout << go(0);
+
+  return 0;
+}

--- a/고석환/백준/S3_14501_퇴사/solution.js
+++ b/고석환/백준/S3_14501_퇴사/solution.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+// const input = fs.readFileSync('./input.txt').toString().trim().split('\n');
+
+const N = +input[0];
+const arr =input.slice(1).map((v) => v.split(' ').map(Number));
+
+const go = (idx, memo = {}) => {
+  if(idx >= N) return 0;
+
+  if(memo[idx]) return memo[idx];
+
+  let max = 0;
+  for(let i = idx; i < N; i++) {
+    const [day, price] = arr[i];
+    
+    if(i + day <= N) {
+      max = Math.max(max, price + go(i + day, memo));
+    }
+  }
+
+  max = Math.max(max, go(idx + 1, memo));
+
+  memo[idx] = max;
+  return max;
+
+}
+
+const answer = () => {
+  return go(0);
+}
+
+console.log(answer(arr));


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름: 퇴사**
- **출처: 백준** 
- https://www.acmicpc.net/problem/14501

## 🚀 해결 방법
- 처음에 그리디(정렬 또는 우선순위 큐)로 풀릴 줄 알아서 시도했는데 가중치가 달라 정렬이나 우선순위큐를 통해 순서를 바꾸면 풀 수 없음
- 따라서 날짜를 `idx`로 잡고 탑다운 dp 풀이 시도

## 📌 핵심 아이디어
- 해당 인덱스를 포함, 포함하지 않는 두가지 재귀
- dp는 기저사례, 메모이제이션, 로직, 초기화 순으로 풀기

## ⏳ 시간 복잡도
- O(N)

## ✅ 실행 결과
<img width="655" alt="스크린샷 2025-04-06 오후 6 12 03" src="https://github.com/user-attachments/assets/64eb32c7-3154-433c-8b96-d2ca3968c16a" />

## 💡 기타 참고 사항
- js로 dp 풀이할 때 `memo = {}` 객체 사용하는 것에 익숙해지기

