### PR TITLE
[백준]곱셈_고동현

### DIFF
--- a/고동현/곱셈.py
+++ b/고동현/곱셈.py
@@ -1,0 +1,15 @@
+a,b,c = map(int,input().split())
+
+def mod_pow(a,b,c):
+    result = 1
+    a = a%c
+    while b > 0:
+        if b % 2 == 1:
+            result = (result*a) % c
+        a = (a * a) %c
+        b //= 2
+    return result
+
+print(mod_pow(a,b,c))
+
+#print(pow(a,b,c)) -> 파이썬은 내장함수에 모듈러 거듭제곱 pow가 있음.


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름:** 곱셈
- **출처:** 백준 

## 🚀 해결 방법
- 모듈러 거듭제곱을 이용한 풀이방법 사용
- python 내장함수 pow

## 📌 핵심 아이디어
- (a^b)%c = ((a mod c^b) % c) 공식을 이용해서 mod_pow함수를 정의한 후 풀이.
- 큰수일 경우 메모리 부족과 시간초과가 발생할 수 있기 때문에, 큰수가 되기 전에 미리 수를 줄이는 방법
- 분할 정복으로 풀수 있지만, 파이썬에 내장함수가 있기 떄문에 원리를 공부했음.

## ⏳ 시간 복잡도
- O(logb)

## ✅ 실행 결과
- [ ] 테스트 케이스 통과 여부
- [ ] 코드 실행 결과 (예제 입력/출력 포함)

## 💡 기타 참고 사항
- 분할 정복으로 풀 수 있음.

