### PR TITLE
ksh / 백준 S1 2178 미로 탐색 풀이

### DIFF
--- a/고석환/백준/S1_2178_미로_탐색/solution.cpp
+++ b/고석환/백준/S1_2178_미로_탐색/solution.cpp
@@ -1,0 +1,46 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+const int dy[] = {-1, 0, 1, 0};
+const int dx[] = {0, 1, 0, -1};
+
+int n, m, visited[104][104];
+char a[104][104];
+string temp;
+
+int main() {
+  cin >> n >> m;
+
+  for (int i = 0; i < n; i++) {
+    cin >> temp;
+
+    for (int j = 0; j < m; j++) a[i][j] = temp[j];
+  }
+
+  visited[0][0] = 1;
+  queue<pair<int, int>> q;
+  q.push({0, 0});
+  int y, x;
+
+  while (q.size()) {
+    tie(y, x) = q.front();
+    q.pop();
+
+    for (int i = 0; i < 4; i++) {
+      int ny = y + dy[i];
+      int nx = x + dx[i];
+
+      if (ny < 0 || nx < 0 || ny >= n || nx >= m) continue;
+      if (visited[ny][nx] || a[ny][nx] == '0') continue;
+
+      visited[ny][nx] = visited[y][x] + 1;
+      q.push({ny, nx});
+    }
+  }
+
+  cout << visited[n - 1][m - 1];
+
+  return 0;
+}
+
+// BFS 최단 거리

--- a/고석환/백준/S1_2178_미로_탐색/solution.js
+++ b/고석환/백준/S1_2178_미로_탐색/solution.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+// const input = fs.readFileSync('./input.txt').toString().trim().split('\n');
+
+const [n, m] = input[0].split(' ').map(Number);
+const map = input.slice(1).map(a => a.split('').map(Number))
+
+const dir = [
+  [-1, 0],
+  [0, 1],
+  [1, 0],
+  [0, -1]
+];
+
+const visited = Array.from({length: n}, () => Array(m).fill(0));
+
+const answer = (n, m, map) => {
+  visited[0][0] = 1;
+  const queue = [];
+  
+  queue.push([0, 0]);
+
+  while(queue.length > 0){
+    const [y, x] = queue.shift();
+
+    for (const [dy, dx] of dir){
+      const [ny, nx] = [y + dy, x + dx];
+
+      if(ny < 0 || nx < 0 || ny >= n || nx >= m) continue;
+      if(visited[ny][nx] || map[ny][nx] === 0) continue;
+
+      visited[ny][nx] = visited[y][x] + 1;
+      queue.push([ny, nx]);
+    }
+
+  }
+
+  return visited[n-1][m-1];
+}
+
+console.log(answer(n, m, map));


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름: 미로 탐색**
- **출처: 백준**
- https://www.acmicpc.net/problem/2178

## 🚀 해결 방법
- `queue`를 통해 bfs 알고리즘 구현
- 네 방향 map 탐색

## 📌 핵심 아이디어
- BFS 를 통해 가중치가 1인 map에서 최단거리

## ⏳ 시간 복잡도
- O( )

## ✅ 실행 결과
![image](https://github.com/user-attachments/assets/4b05e2f0-2140-49c1-ab0e-210df6bbaccb)

## 💡 기타 참고 사항
- 네 방향 map을 탐색하는 기본 구조는 빠르게 구현할 수 있어야 함.
- js 스타일에 맞는 코딩 스타일 익히기
- `const visited = Array.from({length: n},  () => Array(m).fill(0))` Array.from 을 통해 2차원 배열 생성

