### PR TITLE
ksh / 백준 S3 2606 바이러스 풀이

### DIFF
--- a/고석환/백준/S3_2606_바이러스/solution.cpp
+++ b/고석환/백준/S3_2606_바이러스/solution.cpp
@@ -1,0 +1,31 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int n, m, from, to, visited[104];
+vector<int> adj[104];
+
+int dfs(int here) {
+  visited[here] = 1;
+  int ret = 0;
+
+  for (int there : adj[here]) {
+    if (visited[there]) continue;
+
+    ret += 1 + dfs(there);
+  }
+
+  return ret;
+}
+
+int main() {
+  cin >> n >> m;
+  for (int i = 0; i < m; i++) {
+    cin >> from >> to;
+    adj[from].push_back(to);
+    adj[to].push_back(from);
+  }
+
+  cout << dfs(1);
+
+  return 0;
+}

--- a/고석환/백준/S3_2606_바이러스/solution.js
+++ b/고석환/백준/S3_2606_바이러스/solution.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+// const input = fs.readFileSync('./input.txt').toString().trim().split('\n');
+
+const N = +input[0];
+const adj = Array.from({length: N+1}, () => []);
+
+input.slice(2).map(line => line.split(' ').map(Number)).forEach(([from, to]) => {
+  adj[from].push(to);
+  adj[to].push(from);
+})
+
+const dfs = (here, visited = new Set()) => {
+  visited.add(here);
+  let ret = 0;
+
+  for(let there of adj[here]){
+    if(visited.has(there)) continue;
+    ret += 1 + dfs(there, visited);
+  }
+  return ret;
+}
+
+const answer = () => {
+  return dfs(1);
+}
+
+console.log(answer());


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름: 바이러스**
- **출처: 백준** 
- https://www.acmicpc.net/problem/2606

## 🚀 해결 방법
- dfs를 활용한 방문 노드 세기

## 📌 핵심 아이디어
- 재귀 돌면서 노드 방문할 때마다 +1

## ⏳ 시간 복잡도
- O(N)

## ✅ 실행 결과
![image](https://github.com/user-attachments/assets/d23dd37c-041b-450b-9577-b0c7bafee3bd)

## 💡 기타 참고 사항
- js의 경우 `Set()`을 활용한 `visited` 방문 처리

