### PR TITLE
ksh / 프로그래머스 LV2 뒤에 있는 큰 수 찾기 풀이

### DIFF
--- a/고석환/프로그래머스/LV2_뒤에_있는_큰_수_찾기/solution.cpp
+++ b/고석환/프로그래머스/LV2_뒤에_있는_큰_수_찾기/solution.cpp
@@ -1,0 +1,18 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+vector<int> solution(vector<int> numbers) {
+  vector<int> answer(numbers.size(), -1);
+  stack<int> stk;
+
+  for (int i = 0; i < numbers.size(); i++) {
+    while (!stk.empty() && numbers[stk.top()] < numbers[i]) {
+      answer[stk.top()] = numbers[i];
+      stk.pop();
+    }
+    stk.push(i);
+  }
+
+  return answer;
+}

--- a/고석환/프로그래머스/LV2_뒤에_있는_큰_수_찾기/solution.js
+++ b/고석환/프로그래머스/LV2_뒤에_있는_큰_수_찾기/solution.js
@@ -1,0 +1,13 @@
+function solution(numbers) {
+    const answer = Array(numbers.length).fill(-1);
+    const stk = [];
+    
+    numbers.forEach((e, i) => {
+        while(stk.length > 0 && numbers[stk[stk.length - 1]] < e){
+           answer[stk.pop()] = e;
+        }
+        stk.push(i);
+    })
+    
+    return answer;
+}


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름: 뒤에 있는 큰 수 찾기**
- **출처: 프로그래머스**

## 🚀 해결 방법
- Stack 자료형을 활용한 짝짓기 문제

## 📌 핵심 아이디어
- 배열의 크기가 최대 100만이므로 브루트포스 시 `O(N^2)` 시간초과 발생
- 처음에 배열 역방향, 그리디 등 방법을 생각했으나 해결하지 못함
- 이전에 백준의 오큰수 문제에서 스택을 활용해서 문제를 푼 경험을 통해 스택으로 문제 풀이
- 스택에 인덱스 값을 계속해서 넣고, 현재 인덱스와 스택에 있는 과거 인덱스의 `numbers` 값을 비교하여, 현재 값을 바탕으로 이전 값들을 업데이트 하는 방식

## ⏳ 시간 복잡도
- O(N)

## ✅ 실행 결과


## 💡 기타 참고 사항
- 짝을 짓는 문제는 스택 자료구조를 떠올려볼 수 있다
- 이런 류의 문제는 풀이 방식을 알고 있으면 좋음

