### PR TITLE
ksh / 프로그래머스 타겟 넘버 풀이

### DIFF
--- a/고석환/프로그래머스/LV2_타겟_넘버/solution.cpp
+++ b/고석환/프로그래머스/LV2_타겟_넘버/solution.cpp
@@ -1,0 +1,21 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int go(int idx, int v, int target, vector<int> &numbers) {
+  // 기저사례
+  if (idx == numbers.size()) {
+    if (v == target)
+      return 1;
+    else
+      return 0;
+  }
+
+  // 로직
+  return go(idx + 1, v + numbers[idx], target, numbers) +
+         go(idx + 1, v - numbers[idx], target, numbers);
+}
+
+int solution(vector<int> numbers, int target) {
+  return go(0, 0, target, numbers);
+}

--- a/고석환/프로그래머스/LV2_타겟_넘버/solution.js
+++ b/고석환/프로그래머스/LV2_타겟_넘버/solution.js
@@ -1,0 +1,9 @@
+const go = (idx, v, target, numbers) => {
+    if(idx === numbers.length) return v === target ? 1 : 0;
+    
+    return go(idx + 1, v + numbers[idx], target, numbers) + go(idx + 1, v - numbers[idx], target, numbers);
+}
+
+function solution(numbers, target) {
+    return go(0, 0, target, numbers);
+}


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름: 타겟 넘버**
- **출처: 프로그래머스**

## 🚀 해결 방법
- 재귀를 통한 완전 탐색

## 📌 핵심 아이디어
- `2^20`은 1048576 이므로 완탐해도 시간초과 안남
- 재귀를 통해 `return go(v + numbers[idx]) + go(v - numbers[idx])`

## ⏳ 시간 복잡도
- `O(2^N)`

## ✅ 실행 결과

## 💡 기타 참고 사항
- 문제의 조건이 빡빡해져 시간초과가 발생할 수 있으면, 백트래킹 고려

