### PR TITLE
백준 바이러스

### DIFF
--- a/김용준/바이러스.py
+++ b/김용준/바이러스.py
@@ -1,0 +1,28 @@
+import sys
+
+n = int(sys.stdin.readline().strip())
+m = int(sys.stdin.readline().strip())
+
+g = {}
+for i in range(1, n+1):
+    g[i] = []  
+
+for i in range(m):
+    node, edge = map(int, sys.stdin.readline().strip().split())
+    g[node].append(edge)
+    g[edge].append(node)
+
+visited = [] 
+stack = [1]  
+
+while stack:
+    current = stack.pop() 
+    
+    if current not in visited: 
+        visited.append(current) 
+        
+        for next_node in g[current]: 
+            if next_node not in visited: 
+                stack.append(next_node) 
+
+print(len(visited) - 1)


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름:** 바이러스
- **출처:** 백준

## 🚀 해결 방법
- n이 주어졌으니 모든 노드를 빈 리스트로 초기화
- 단방향이 아니므로 양방향으로 그래프를 생성
- dfs 수행

## 📌 핵심 아이디어
- dfs

## ⏳ 시간 복잡도
- O(n² + nm)

## ✅ 실행 결과
![image](https://github.com/user-attachments/assets/59b982cf-0af2-44ac-93bb-2c6736d7ec4f)

## 💡 기타 참고 사항
- 만약 visited를 리스트 대신 집합(set)으로 사용하면, in 연산의 시간 복잡도가 O(1)로 감소하여 전체 시간 복잡도를 O(n + m)으로 개선 가능