### PR TITLE
백준 G5 2493 탑 풀이

### DIFF
--- a/고석환/백준/G5_2493_탑/solution.cpp
+++ b/고석환/백준/G5_2493_탑/solution.cpp
@@ -1,0 +1,29 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int n, temp, ret[500004];
+stack<pair<int, int>> stk;
+
+int main() {
+  cin >> n;
+  for (int i = 0; i < n; i++) {
+    cin >> temp;
+
+    while (!stk.empty()) {
+      if (stk.top().second < temp)
+        stk.pop();
+      else {
+        ret[i] = stk.top().first;
+        break;
+      }
+    }
+    stk.push({i + 1, temp});
+  }
+
+  for (int i = 0; i < n; i++) {
+    cout << ret[i] << ' ';
+  }
+
+  return 0;
+}

--- a/고석환/백준/G5_2493_탑/solution.js
+++ b/고석환/백준/G5_2493_탑/solution.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+
+const arr = input[1].split(' ').map(Number);
+
+const answer = (towers) => {
+  const stk = [];
+  const ret = Array.from({length: arr.length}).fill(0);
+
+  towers.forEach((tower, idx) => {
+    while(stk.length > 0){
+      const [i, e] = stk[stk.length - 1];
+
+      if(e >= tower){
+        ret[idx] = i + 1;
+        break;
+      }else stk.pop();
+      
+    }
+    stk.push([idx, tower]);
+  })
+
+  return ret.join(' ');
+}
+
+console.log(answer(arr));


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름: 탑**
- **출처: 백준**
https://www.acmicpc.net/problem/2493\

## 🚀 해결 방법
- stack을 활용

## 📌 핵심 아이디어
- stack을 활용하여 0으로 초기화된 `ret` 배열을 채워나감
- stack 에 pair 로 인덱스와 타워의 높이 값을 둘다 저장

## ⏳ 시간 복잡도
- O(N)

## ✅ 실행 결과
https://www.acmicpc.net/problem/2493

## 💡 기타 참고 사항
- js에서 시간초과가 나서 검색해보았더니 결과 출력을 `process.stdout.write(e + ' '));`를 통해 했었는데, 최대 50만번 문자열 출력때문에 시간초과 발생
- 따라서 `ret` 배열을 `join`하는 방식으로 변경 `return ret.join(' ');`
