### PR TITLE
lji/문서검색

### DIFF
--- a/이재인/백준/4주차문제/문서검색.py
+++ b/이재인/백준/4주차문제/문서검색.py
@@ -1,0 +1,15 @@
+import sys
+input = sys.stdin.readline
+
+doc = list(input().strip())
+a = list(input().strip())
+
+
+count =0
+i=0
+while i<len(doc):
+    if doc[i:i+len(a)] == a:
+        i += len(a)
+        count += 1
+    else: i+=1
+print(count)


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름:** 문서검색
- **출처:** 백준 

## 🚀 해결 방법
- 브루트포스

## 📌 핵심 아이디어
- while 반복을 통해 문서 내의 i:len(a) 만큼 슬라이싱 한 것이 a와 같다면 
카운트 +1, i는 a의 길이만큼 증가
- 문서 길이만큼 반복

## ⏳ 시간 복잡도
- O(len(doc) * len(a) ) / 문서 길이 * 검색단어 길이

## ✅ 실행 결과
<img width="747" alt="스크린샷 2025-04-18 오전 11 27 48" src="https://github.com/user-attachments/assets/ea8f1cac-767d-48a3-bf90-e70496a1c92c" />

## 💡 기타 참고 사항
- (추가적으로 공유할 내용이 있다면 적어주세요)

처음 코드는 아래 코드였는데
예제는 통과하지만 문자열이 계속해서 겹치는 경우 반례가 존재해서 오답 처리 되었음.
````
import sys
input = sys.stdin.readline

doc = input().strip()
a = input().strip()
count =0
while True:
    if a in doc:
        doc = doc.replace(a, "", 1)
        count +=1
    else:
        break
print(count)
````




