### PR TITLE
ksh / 백준 S5 1543 문서 검색 풀이

### DIFF
--- a/고석환/백준/S5_1543_문서_검색/solution.cpp
+++ b/고석환/백준/S5_1543_문서_검색/solution.cpp
@@ -1,0 +1,22 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int ret;
+string s, delimeter;
+
+int main() {
+  getline(cin, s);
+  getline(cin, delimeter);
+
+  auto start = 0;
+  auto end = s.find(delimeter);
+
+  while (end != string::npos) {
+    ret++;
+    start = end + delimeter.size();
+    end = s.find(delimeter, start);
+  }
+
+  cout << ret;
+  return 0;
+}

--- a/고석환/백준/S5_1543_문서_검색/solution.js
+++ b/고석환/백준/S5_1543_문서_검색/solution.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+
+const [s, delimeter] = input;
+
+const answer = (s, delimeter) => {
+    let ret = 0;
+
+    let start = 0;
+    let end = s.match(delimeter)
+
+    while(end !== null){
+        s = s.substring(end.index + delimeter.length);
+        
+        ret++;
+        start = end.index;
+        end = s.match(delimeter);
+    }
+
+    return ret;
+}
+
+console.log(answer(s, delimeter));
+
+
+


### PR DESCRIPTION
## 📝 문제 정보
- **문제 이름: 문서 검색**
- **출처: 백준**
- https://www.acmicpc.net/problem/1543

## 🚀 해결 방법
- cpp `split()` 구현과 동일한 로직
- 

## 📌 핵심 아이디어
- 문자열의 앞에서부터 찾는 `cpp find()`, `js match()` 함수 사용하여 인덱스 찾은 후, 타겟 문자열의 길이만큼 넘기며 탐색
- `cpp sub_string()`, `js subString()` 활용하여 문자열 length 만큼 자르기

## ⏳ 시간 복잡도
- O(N)

## ✅ 실행 결과
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/2ea244a1-4c1f-4757-bce4-75a805567f31" />

## 💡 기타 참고 사항
- `find()`, `match()` 가 못찾을 때를 `while`문의 종료 조건으로 사용

